### PR TITLE
Refactor block registry and add block importer command

### DIFF
--- a/docs/content/1_docs/5_block-editor/13_importing-shared-blocks.md
+++ b/docs/content/1_docs/5_block-editor/13_importing-shared-blocks.md
@@ -1,0 +1,37 @@
+# Importing shared blocks
+
+Twill 3.{{< version >}} introduces a more modular block registry and a first-party importer command that makes it easier to reuse
+blocks across projects.
+
+## Modular block registration
+
+The block registry now lives inside `A17\Twill\Services\Blocks\BlockRegistry`. It is resolved as a singleton and orchestrates
+all block directories, dynamic repeaters and component-based blocks in one place. This makes it possible to register additional
+directories at runtime without reloading the application. If you previously manipulated static properties on `TwillBlocks`, you can
+now call the higher-level helpers provided by the facade:
+
+```php
+TwillBlocks::registerSourceDirectory(resource_path('views/twill/marketing'), \A17\Twill\Services\Blocks\Block::TYPE_BLOCK, 'app');
+TwillBlocks::registerPackageRepeatersDirectory($packagePath, 'Vendor\\Package\\Blocks');
+```
+
+The registry will lazily read the directories and merge their block definitions only when they are needed, which keeps bootstrapping
+fast even when many block packs are available.
+
+## Importing blocks from archives or folders
+
+Blocks can now be shared by zipping (or sharing directly) a directory that contains a `blocks` folder or a `views/twill/blocks`
+structure. Developers can import those bundles using the new Artisan command:
+
+```bash
+php artisan twill:block:import blocks/my-team-package.zip
+```
+
+The command accepts either a directory or a `.zip` archive. By default, existing block views are not overwritten; pass `--force`
+if you want to replace local files. During the import the command reports which files were copied or skipped and surfaces any
+warnings (for example, empty directories).
+
+If the bundle contains a `twill-block.json` manifest the importer reads it to locate view directories and exposes suggested
+configuration additions. Those configuration snippets are printed as JSON so they can be merged into `config/twill.php` manually.
+
+This workflow makes it straightforward to share curated block libraries between projects or teams without manually copying files.

--- a/src/Commands/BlockImport.php
+++ b/src/Commands/BlockImport.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace A17\Twill\Commands;
+
+use A17\Twill\Services\Blocks\BlockImporter;
+use Illuminate\Console\Command;
+use RuntimeException;
+
+class BlockImport extends Command
+{
+    protected $signature = 'twill:block:import {source : Path to the block package or archive.} {--force : Overwrite existing files.}';
+
+    protected $description = 'Import block templates from a directory or archive.';
+
+    public function __construct(protected BlockImporter $importer)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $result = $this->importer->import($this->argument('source'), (bool) $this->option('force'));
+        } catch (RuntimeException $exception) {
+            $this->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $this->info('Imported blocks from: ' . $result->source);
+
+        if ($result->copied !== []) {
+            $this->line('Copied files:');
+            foreach ($result->copied as $path) {
+                $this->line('  • ' . $path);
+            }
+        }
+
+        if ($result->skipped !== []) {
+            $this->line('Skipped existing files (use --force to overwrite):');
+            foreach ($result->skipped as $path) {
+                $this->line('  • ' . $path);
+            }
+        }
+
+        if ($result->hasWarnings()) {
+            $this->warn('Warnings:');
+            foreach ($result->warnings as $warning) {
+                $this->line('  • ' . $warning);
+            }
+        }
+
+        if ($result->hasConfigRecommendations()) {
+            $this->line('');
+            $this->comment('Suggested configuration additions (merge into config/twill.php):');
+            $this->line(json_encode($result->configRecommendations(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Services/Blocks/BlockImportResult.php
+++ b/src/Services/Blocks/BlockImportResult.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace A17\Twill\Services\Blocks;
+
+class BlockImportResult
+{
+    public array $copied = [];
+
+    public array $skipped = [];
+
+    public array $warnings = [];
+
+    public function __construct(public string $source, public ?BlockManifest $manifest = null)
+    {
+    }
+
+    public function addCopied(string $path): void
+    {
+        $this->copied[] = $path;
+    }
+
+    public function addSkipped(string $path): void
+    {
+        $this->skipped[] = $path;
+    }
+
+    public function addWarning(string $message): void
+    {
+        $this->warnings[] = $message;
+    }
+
+    public function hasWarnings(): bool
+    {
+        return $this->warnings !== [];
+    }
+
+    public function hasConfigRecommendations(): bool
+    {
+        return $this->manifest?->hasConfig() ?? false;
+    }
+
+    public function configRecommendations(): array
+    {
+        return $this->manifest?->config() ?? [];
+    }
+}

--- a/src/Services/Blocks/BlockImporter.php
+++ b/src/Services/Blocks/BlockImporter.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace A17\Twill\Services\Blocks;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use RuntimeException;
+use ZipArchive;
+
+class BlockImporter
+{
+    protected array $defaultViewMappings = [
+        'twill/blocks' => [
+            'views/twill/blocks',
+            'resources/views/twill/blocks',
+            'blocks',
+        ],
+        'twill/blocks/repeaters' => [
+            'views/twill/blocks/repeaters',
+            'resources/views/twill/blocks/repeaters',
+            'repeaters',
+        ],
+    ];
+
+    protected ?string $temporaryExtraction = null;
+
+    public function __construct(protected Filesystem $files)
+    {
+    }
+
+    public function import(string $source, bool $force = false): BlockImportResult
+    {
+        try {
+            $root = $this->resolveSource($source);
+
+            $manifest = BlockManifest::fromDirectory($root);
+            $directories = $this->discoverDirectories($root, $manifest);
+
+            $result = new BlockImportResult($root, $manifest);
+
+            if ($directories === []) {
+                $result->addWarning('No block views were discovered in the provided source.');
+
+                return $result;
+            }
+
+            foreach ($directories as $target => $sources) {
+                foreach ($sources as $sourceDirectory) {
+                    $files = $this->files->allFiles($sourceDirectory);
+
+                    if ($files === []) {
+                        $result->addWarning('Directory ' . $sourceDirectory . ' did not contain any files.');
+
+                        continue;
+                    }
+
+                    foreach ($files as $file) {
+                        $relative = ltrim(Str::replaceFirst($sourceDirectory, '', $file->getPathname()), DIRECTORY_SEPARATOR);
+                        $destination = resource_path('views' . DIRECTORY_SEPARATOR . trim($target, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $relative);
+                        $normalized = $this->normalizePath($destination);
+
+                        if ($this->files->exists($destination) && ! $force) {
+                            $result->addSkipped($normalized);
+
+                            continue;
+                        }
+
+                        $this->files->ensureDirectoryExists(dirname($destination));
+                        $this->files->copy($file->getPathname(), $destination);
+                        $result->addCopied($normalized);
+                    }
+                }
+            }
+
+            return $result;
+        } finally {
+            $this->cleanupTemporaryExtraction();
+        }
+    }
+
+    protected function discoverDirectories(string $root, ?BlockManifest $manifest): array
+    {
+        $mappings = $manifest?->getViewMappings();
+
+        if ($mappings === []) {
+            $mappings = $this->defaultViewMappings;
+        }
+
+        $directories = [];
+
+        foreach ($mappings as $target => $sources) {
+            $sources = Collection::make($sources)
+                ->map(fn ($path) => rtrim($root, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . trim($path, DIRECTORY_SEPARATOR))
+                ->filter(fn ($path) => $this->files->isDirectory($path))
+                ->values()
+                ->all();
+
+            if ($sources !== []) {
+                $directories[$target] = $sources;
+            }
+        }
+
+        return $directories;
+    }
+
+    protected function resolveSource(string $source): string
+    {
+        $path = $this->guessFullPath($source);
+
+        if (! $this->files->exists($path)) {
+            throw new RuntimeException('Unable to locate blocks at path: ' . $source);
+        }
+
+        if ($this->files->isFile($path)) {
+            return $this->extractArchive($path);
+        }
+
+        return $this->guessRootDirectory($path);
+    }
+
+    protected function guessFullPath(string $source): string
+    {
+        if ($this->files->exists($source)) {
+            return $source;
+        }
+
+        $candidate = base_path($source);
+
+        if ($this->files->exists($candidate)) {
+            return $candidate;
+        }
+
+        return $source;
+    }
+
+    protected function extractArchive(string $archive): string
+    {
+        if (! class_exists(ZipArchive::class)) {
+            throw new RuntimeException('Zip extension is not available to extract block archives.');
+        }
+
+        $zip = new ZipArchive();
+
+        if ($zip->open($archive) !== true) {
+            throw new RuntimeException('Unable to open archive: ' . $archive);
+        }
+
+        $temporary = storage_path('app/twill/tmp-block-' . Str::uuid());
+
+        $this->files->ensureDirectoryExists($temporary);
+
+        if (! $zip->extractTo($temporary)) {
+            $zip->close();
+
+            throw new RuntimeException('Unable to extract archive: ' . $archive);
+        }
+
+        $zip->close();
+
+        $this->temporaryExtraction = $temporary;
+
+        return $this->guessRootDirectory($temporary);
+    }
+
+    protected function guessRootDirectory(string $path): string
+    {
+        $directories = $this->files->directories($path);
+
+        if (count($directories) === 1 && $this->files->isDirectory($directories[0])) {
+            return $directories[0];
+        }
+
+        return $path;
+    }
+
+    protected function normalizePath(string $path): string
+    {
+        $base = base_path() . DIRECTORY_SEPARATOR;
+
+        if (Str::startsWith($path, $base)) {
+            return Str::replaceFirst($base, '', $path);
+        }
+
+        return $path;
+    }
+
+    protected function cleanupTemporaryExtraction(): void
+    {
+        if ($this->temporaryExtraction === null) {
+            return;
+        }
+
+        $this->files->deleteDirectory($this->temporaryExtraction);
+        $this->temporaryExtraction = null;
+    }
+}

--- a/src/Services/Blocks/BlockManifest.php
+++ b/src/Services/Blocks/BlockManifest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace A17\Twill\Services\Blocks;
+
+use Illuminate\Support\Arr;
+
+class BlockManifest
+{
+    public function __construct(
+        public string $name,
+        public ?string $description = null,
+        protected array $views = [],
+        protected array $config = [],
+        protected array $meta = []
+    ) {
+    }
+
+    public static function fromDirectory(string $directory): ?self
+    {
+        $path = rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'twill-block.json';
+
+        if (! file_exists($path)) {
+            return null;
+        }
+
+        $contents = file_get_contents($path);
+
+        if ($contents === false) {
+            return null;
+        }
+
+        $decoded = json_decode($contents, true);
+
+        if (! is_array($decoded)) {
+            return null;
+        }
+
+        $meta = Arr::except($decoded, ['name', 'description', 'views', 'config']);
+
+        return new self(
+            $decoded['name'] ?? basename($directory),
+            $decoded['description'] ?? null,
+            $decoded['views'] ?? [],
+            $decoded['config'] ?? [],
+            $meta
+        );
+    }
+
+    public function hasViews(): bool
+    {
+        return ! empty($this->views);
+    }
+
+    public function getViewMappings(): array
+    {
+        if ($this->views === [] || Arr::isAssoc($this->views) === false) {
+            $sources = array_values($this->views);
+
+            if ($sources === []) {
+                return [];
+            }
+
+            return ['twill/blocks' => $sources];
+        }
+
+        $mappings = [];
+
+        foreach ($this->views as $target => $sources) {
+            $mappings[$target] = is_array($sources) ? $sources : [$sources];
+        }
+
+        return $mappings;
+    }
+
+    public function hasConfig(): bool
+    {
+        return ! empty($this->config);
+    }
+
+    public function config(): array
+    {
+        return $this->config;
+    }
+
+    public function meta(): array
+    {
+        return $this->meta;
+    }
+}

--- a/src/Services/Blocks/BlockRegistry.php
+++ b/src/Services/Blocks/BlockRegistry.php
@@ -1,0 +1,335 @@
+<?php
+
+namespace A17\Twill\Services\Blocks;
+
+use A17\Twill\Services\Forms\InlineRepeater;
+use A17\Twill\View\Components\Blocks\TwillBlockComponent;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class BlockRegistry
+{
+    protected BlockCollection $collection;
+
+    protected array $pendingBlockDirectories = [];
+
+    protected array $pendingRepeaterDirectories = [];
+
+    protected array $pendingComponentNamespaces = [];
+
+    protected array $pendingManualBlocks = [];
+
+    protected bool $hasHydrated = false;
+
+    /**
+     * @var array<string, InlineRepeater>
+     */
+    protected array $dynamicRepeaters = [];
+
+    protected array $loadedDynamicRepeaters = [];
+
+    protected ?array $cropConfigs = null;
+
+    public function __construct(?BlockCollection $collection = null)
+    {
+        $this->collection = $collection ?? new BlockCollection();
+    }
+
+    public function registerBlockDirectory(string $path, string $source, ?string $renderNamespace = null): void
+    {
+        if (isset($this->pendingBlockDirectories[$path])) {
+            return;
+        }
+
+        if ($this->collectionIsHydrated()) {
+            $this->appendBlocks($this->readBlocksFromDirectory($path, $source, Block::TYPE_BLOCK, $renderNamespace));
+
+            return;
+        }
+
+        $this->pendingBlockDirectories[$path] = [
+            'source' => $source,
+            'renderNamespace' => $renderNamespace,
+        ];
+    }
+
+    public function registerRepeaterDirectory(string $path, string $source, ?string $renderNamespace = null): void
+    {
+        if (isset($this->pendingRepeaterDirectories[$path])) {
+            return;
+        }
+
+        if ($this->collectionIsHydrated()) {
+            $this->appendBlocks($this->readBlocksFromDirectory($path, $source, Block::TYPE_REPEATER, $renderNamespace));
+
+            return;
+        }
+
+        $this->pendingRepeaterDirectories[$path] = [
+            'source' => $source,
+            'renderNamespace' => $renderNamespace,
+        ];
+    }
+
+    public function registerComponentNamespace(string $namespace, string $path): void
+    {
+        if (! Str::startsWith($namespace, '\\')) {
+            $namespace = '\\' . $namespace;
+        }
+
+        $this->pendingComponentNamespaces[$namespace] = $path;
+
+        if ($this->collectionIsHydrated()) {
+            $this->consumeComponentNamespaces();
+        }
+    }
+
+    public function registerManualBlock(string $blockClass): void
+    {
+        $this->pendingManualBlocks[$blockClass] = $blockClass;
+
+        if ($this->collectionIsHydrated()) {
+            $this->consumeManualBlocks();
+        }
+    }
+
+    public function registerDynamicRepeater(string $name, InlineRepeater $repeater): void
+    {
+        $this->dynamicRepeaters[$name] = $repeater;
+
+        if ($this->collectionIsHydrated()) {
+            $this->appendDynamicRepeaters();
+        }
+    }
+
+    public function getAvailableRepeaters(): string
+    {
+        return $this->getCollection()->getRepeaters()->mapWithKeys(function (Block $repeater) {
+            return [$repeater->name => $repeater->toList()];
+        })->toJson();
+    }
+
+    public function findByName(string $name): ?Block
+    {
+        return $this->getAll()->first(function (Block $block) use ($name) {
+            return $block->name === $name;
+        });
+    }
+
+    public function findRepeaterByName(string $name): ?Block
+    {
+        $repeater = $this->getRepeaters()->first(function (Block $block) use ($name) {
+            return $block->name === $name;
+        });
+
+        if ($repeater === null) {
+            $repeater = $this->getRepeaters()->first(function (Block $block) use ($name) {
+                return $block->name === 'dynamic-repeater-' . $name;
+            });
+        }
+
+        return $repeater;
+    }
+
+    public function getCollection(): BlockCollection
+    {
+        $this->hydrateCollection();
+
+        return $this->collection;
+    }
+
+    public function getBlocks(bool $withSettingsBlocks = false): Collection
+    {
+        $blocks = $this->getCollection()->getBlockList();
+
+        if ($withSettingsBlocks) {
+            return $blocks->merge($this->getSettingsBlocks());
+        }
+
+        return $blocks;
+    }
+
+    public function getSettingsBlocks(): Collection
+    {
+        return $this->getCollection()->getSettingsList();
+    }
+
+    public function getRepeaters(): Collection
+    {
+        return $this->getCollection()->getRepeaters();
+    }
+
+    public function getAll(): Collection
+    {
+        return $this->getBlocks()->merge($this->getRepeaters())->merge($this->getSettingsBlocks());
+    }
+
+    public function getAllCropConfigs($prefixKey = false): array
+    {
+        if ($this->cropConfigs === null) {
+            $configs = config()->get('twill.block_editor.crops', []);
+            $configs = $configs + (config()->get('twill.repeaters.crops') ?? []);
+
+            foreach ($this->getCollection() as $block) {
+                if (! $block->componentClass) {
+                    continue;
+                }
+
+                $crops = $block->componentClass::getCrops();
+
+                if ($crops !== []) {
+                    $configs = array_merge($configs, $crops);
+                }
+            }
+
+            $this->cropConfigs = $configs;
+        }
+
+        if ($prefixKey) {
+            return Arr::prependKeysWith($this->cropConfigs, 'block_');
+        }
+
+        return $this->cropConfigs;
+    }
+
+    protected function hydrateCollection(): void
+    {
+        $this->consumeRepeaterDirectories();
+        $this->consumeBlockDirectories();
+        $this->consumeComponentNamespaces();
+        $this->consumeManualBlocks();
+        $this->appendDynamicRepeaters();
+        $this->deduplicateTwillBlocks();
+
+        $this->hasHydrated = true;
+    }
+
+    protected function consumeBlockDirectories(): void
+    {
+        foreach ($this->pendingBlockDirectories as $path => $data) {
+            $this->appendBlocks($this->readBlocksFromDirectory(
+                $path,
+                $data['source'],
+                Block::TYPE_BLOCK,
+                $data['renderNamespace'] ?? null
+            ));
+
+            unset($this->pendingBlockDirectories[$path]);
+        }
+    }
+
+    protected function consumeRepeaterDirectories(): void
+    {
+        foreach ($this->pendingRepeaterDirectories as $path => $data) {
+            $this->appendBlocks($this->readBlocksFromDirectory(
+                $path,
+                $data['source'],
+                Block::TYPE_REPEATER,
+                $data['renderNamespace'] ?? null
+            ));
+
+            unset($this->pendingRepeaterDirectories[$path]);
+        }
+    }
+
+    protected function consumeComponentNamespaces(): void
+    {
+        foreach ($this->pendingComponentNamespaces as $namespace => $path) {
+            if (! file_exists($path)) {
+                unset($this->pendingComponentNamespaces[$namespace]);
+
+                continue;
+            }
+
+            $disk = Storage::build([
+                'driver' => 'local',
+                'root' => $path,
+            ]);
+
+            foreach ($disk->allFiles() as $file) {
+                $class = $namespace . '\\' . Str::replace('/', '\\', Str::before($file, '.'));
+                if (is_subclass_of($class, TwillBlockComponent::class)) {
+                    $this->collection->add(Block::forComponent($class));
+                }
+            }
+
+            unset($this->pendingComponentNamespaces[$namespace]);
+        }
+    }
+
+    protected function consumeManualBlocks(): void
+    {
+        foreach ($this->pendingManualBlocks as $class) {
+            $this->collection->add(Block::forComponent($class));
+
+            unset($this->pendingManualBlocks[$class]);
+        }
+    }
+
+    protected function appendBlocks(Collection $blocks): void
+    {
+        $blocks->each(function (Block $block) {
+            $this->collection->add($block);
+        });
+    }
+
+    protected function appendDynamicRepeaters(): void
+    {
+        $this->discoverDynamicRepeaters($this->collection);
+
+        foreach ($this->dynamicRepeaters as $name => $dynamicRepeater) {
+            if (isset($this->loadedDynamicRepeaters[$name])) {
+                continue;
+            }
+
+            $this->collection->add($dynamicRepeater->asBlock());
+            $this->loadedDynamicRepeaters[$name] = true;
+        }
+    }
+
+    protected function discoverDynamicRepeaters(Collection $collection): void
+    {
+        foreach ($collection as $item) {
+            if (! $item instanceof Block || ! $item->componentClass) {
+                continue;
+            }
+
+            $component = new $item->componentClass();
+            $component->getForm()->registerDynamicRepeaters();
+        }
+    }
+
+    protected function deduplicateTwillBlocks(): void
+    {
+        $appBlocks = $this->collection->where('source', '!=', Block::SOURCE_TWILL);
+
+        $this->collection = $this->collection->filter(function ($item) use ($appBlocks) {
+            return ! $appBlocks->contains(function ($block) use ($item) {
+                return $item->source === Block::SOURCE_TWILL && $item->name === $block->name;
+            });
+        });
+    }
+
+    protected function readBlocksFromDirectory(
+        string $directory,
+        string $source,
+        string $type,
+        ?string $renderNamespace = null
+    ): Collection {
+        if (! File::exists($directory)) {
+            return new Collection();
+        }
+
+        return collect(File::files($directory))->map(function ($file) use ($source, $type, $renderNamespace) {
+            return Block::make($file, $type, $source, null, $renderNamespace);
+        });
+    }
+
+    protected function collectionIsHydrated(): bool
+    {
+        return $this->hasHydrated;
+    }
+}

--- a/src/TwillBlocks.php
+++ b/src/TwillBlocks.php
@@ -4,258 +4,68 @@ namespace A17\Twill;
 
 use A17\Twill\Services\Blocks\Block;
 use A17\Twill\Services\Blocks\BlockCollection;
+use A17\Twill\Services\Blocks\BlockRegistry;
 use A17\Twill\Services\Forms\InlineRepeater;
-use A17\Twill\View\Components\Blocks\TwillBlockComponent;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\File;
-use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Str;
 
 class TwillBlocks
 {
-    /**
-     * @var array<string, array>
-     */
-    public static $blockDirectories = [];
+    public function __construct(protected BlockRegistry $registry)
+    {
+    }
 
-    /**
-     * @var array<string, array>
-     */
-    public static $repeatersDirectories = [];
-
-    /**
-     * @var array<string, string>
-     */
-    public static $componentBlockNamespaces = [];
-
-    /**
-     * @var array<string, InlineRepeater>
-     */
-    public static $dynamicRepeaters = [];
-
-    /**
-     * @var array
-     */
-    public static $loadedDynamicRepeaters = [];
-
-    /**
-     * @var array<string, string>
-     */
-    public static $manualBlocks = [];
-
-    /**
-     * @return A17\Twill\Services\Blocks\BlockCollection
-     */
-    private ?BlockCollection $blockCollection = null;
-
-    private array $cropConfigs = [];
-
-    /**
-     * Registers a blocks directory.
-     *
-     * When the blockCollection is already initialized, we read the blocks and merge them in.
-     * If the blockCollection is not yet initialized, we add it to the local static so that we
-     * can process it once the collection is needed.
-     */
     public function registerPackageBlocksDirectory(string $path, ?string $renderNamespace = null): void
     {
-        if (! isset(self::$blockDirectories[$path])) {
-            if (isset($this->blockCollection)) {
-                $this->getBlockCollection()->merge(
-                    $this->readBlocksFromDirectory($path, Block::SOURCE_VENDOR, Block::TYPE_BLOCK)
-                );
-            } else {
-                self::$blockDirectories[$path] = [
-                    'source' => Block::SOURCE_VENDOR,
-                    'renderNamespace' => $renderNamespace,
-                ];
-            }
+        $this->registry->registerBlockDirectory($path, Block::SOURCE_VENDOR, $renderNamespace);
+    }
+
+    public function registerPackageRepeatersDirectory(string $path, ?string $renderNamespace = null): void
+    {
+        $this->registry->registerRepeaterDirectory($path, Block::SOURCE_VENDOR, $renderNamespace);
+    }
+
+    public function registerSourceDirectory(string $path, string $type, string $source, ?string $renderNamespace = null): void
+    {
+        if ($type === Block::TYPE_BLOCK) {
+            $this->registry->registerBlockDirectory($path, $source, $renderNamespace);
+        } elseif ($type === Block::TYPE_REPEATER) {
+            $this->registry->registerRepeaterDirectory($path, $source, $renderNamespace);
         }
-    }
-
-    public function registerDynamicRepeater(string $name, InlineRepeater $repeater): void
-    {
-        self::$dynamicRepeaters[$name] = $repeater;
-    }
-
-    public function discoverDynamicRepeaters(Collection $collection): void
-    {
-        /** @var Block $item */
-        foreach ($collection as $item) {
-            if ($item->componentClass) {
-                $component = new $item->componentClass();
-                $component->getForm()->registerDynamicRepeaters();
-            }
-        }
-    }
-
-    public function getAvailableRepeaters(): string
-    {
-        $baseList = $this->getBlockCollection()->getRepeaters()->mapWithKeys(function (Block $repeater) {
-            return [$repeater->name => $repeater->toList()];
-        });
-
-        return $baseList->toJson();
     }
 
     public function registerComponentBlocks(string $namespace, string $path): void
     {
-        if (! Str::startsWith($namespace, '\\')) {
-            $namespace = '\\' . $namespace;
-        }
-
-        self::$componentBlockNamespaces[$namespace] = $path;
+        $this->registry->registerComponentNamespace($namespace, $path);
     }
 
-    /**
-     * Registers a repeaters directory.
-     *
-     * When the blockCollection is already initialized, we read the repeaters and merge them in.
-     * If the blockCollection is not yet initialized, we add it to the local static so that we
-     * can process it once the collection is needed.
-     */
-    public function registerPackageRepeatersDirectory(string $path, ?string $renderNamespace = null): void
+    public function registerDynamicRepeater(string $name, InlineRepeater $repeater): void
     {
-        if (! isset(self::$repeatersDirectories[$path])) {
-            if (isset($this->blockCollection)) {
-                $this->getBlockCollection()->merge(
-                    $this->readBlocksFromDirectory($path, Block::SOURCE_VENDOR, Block::TYPE_REPEATER)
-                );
-            } else {
-                self::$repeatersDirectories[$path] = [
-                    'source' => Block::SOURCE_VENDOR,
-                    'renderNamespace' => $renderNamespace,
-                ];
-            }
-        }
-    }
-
-    /**
-     * Only when the block collection is actually requested we parse all the information.
-     */
-    public function getBlockCollection(): BlockCollection
-    {
-        if (! isset($this->blockCollection)) {
-            $this->blockCollection = new BlockCollection();
-        }
-
-        // Consume the repeatersDirectories. We act a bit dumb here by not taking into account duplicates
-        // as a package should only register a directory once.
-        foreach (self::$repeatersDirectories as $repeaterDir => $data) {
-            foreach (
-                $this->readBlocksFromDirectory(
-                    $repeaterDir,
-                    $data['source'],
-                    Block::TYPE_REPEATER,
-                    $data['renderNamespace']
-                ) as $repeater
-            ) {
-                $this->blockCollection->add($repeater);
-            }
-
-            unset(self::$repeatersDirectories[$repeaterDir]);
-        }
-
-        foreach (self::$blockDirectories as $blockDir => $data) {
-            foreach (
-                $this->readBlocksFromDirectory(
-                    $blockDir,
-                    $data['source'],
-                    Block::TYPE_BLOCK,
-                    $data['renderNamespace']
-                ) as $block
-            ) {
-                $this->blockCollection->add($block);
-            }
-
-            unset(self::$blockDirectories[$blockDir]);
-        }
-
-        foreach (self::$componentBlockNamespaces as $namespace => $path) {
-            if (file_exists($path)) {
-                $disk = Storage::build([
-                    'driver' => 'local',
-                    'root' => $path,
-                ]);
-
-                foreach ($disk->allFiles() as $file) {
-                    $class = $namespace . '\\' . Str::replace('/', '\\', Str::before($file, '.'));
-                    if (is_subclass_of($class, TwillBlockComponent::class)) {
-                        $this->blockCollection->add(
-                            Block::forComponent($class)
-                        );
-                    }
-                }
-            }
-
-            unset(self::$componentBlockNamespaces[$namespace]);
-        }
-
-        foreach (self::$manualBlocks as $class) {
-            $this->blockCollection->add(
-                Block::forComponent($class)
-            );
-
-            unset(self::$manualBlocks[$class]);
-        }
-
-        $this->discoverDynamicRepeaters($this->blockCollection);
-
-        foreach (self::$dynamicRepeaters as $name => $dynamicRepeater) {
-            if (! isset(self::$loadedDynamicRepeaters[$name])) {
-                $this->blockCollection->add($dynamicRepeater->asBlock());
-                self::$loadedDynamicRepeaters[$name] = true;
-            }
-        }
-
-        // remove duplicate Twill blocks
-        $appBlocks = $this->blockCollection->where('source', '!=', Block::SOURCE_TWILL);
-        $this->blockCollection = $this->blockCollection->filter(function ($item) use ($appBlocks) {
-            return ! $appBlocks->contains(function ($block) use ($item) {
-                return $item->source === Block::SOURCE_TWILL && $item->name === $block->name;
-            });
-        });
-
-        return $this->blockCollection;
+        $this->registry->registerDynamicRepeater($name, $repeater);
     }
 
     public function registerManualBlock(string $blockClass): void
     {
-        self::$manualBlocks[$blockClass] = $blockClass;
+        $this->registry->registerManualBlock($blockClass);
+    }
+
+    public function getBlockCollection(): BlockCollection
+    {
+        return $this->registry->getCollection();
+    }
+
+    public function getAvailableRepeaters(): string
+    {
+        return $this->registry->getAvailableRepeaters();
     }
 
     public function findByName(string $name): ?Block
     {
-        return $this->getAll()->first(function (Block $block) use ($name) {
-            return $block->name === $name;
-        });
+        return $this->registry->findByName($name);
     }
 
     public function findRepeaterByName(string $name): ?Block
     {
-        $repeater = $this->getRepeaters()->first(function (Block $block) use ($name) {
-            return $block->name === $name;
-        });
-
-        if ($repeater === null) {
-            // Search for the dynamic one.
-            $repeater = $this->getRepeaters()->first(function (Block $block) use ($name) {
-                return $block->name === 'dynamic-repeater-' . $name;
-            });
-        }
-
-        return $repeater;
-    }
-
-    /**
-     * Gets all blocks and repeaters.
-     *
-     * @return Collection|Block[]
-     */
-    public function getAll(): Collection
-    {
-        return $this->getBlocks()->merge($this->getRepeaters())->merge($this->getSettingsBlocks());
+        return $this->registry->findRepeaterByName($name);
     }
 
     /**
@@ -263,18 +73,12 @@ class TwillBlocks
      */
     public function getBlocks(bool $withSettingsBlocks = false): Collection
     {
-        $blocks = $this->getBlockCollection()->getBlockList();
-
-        if ($withSettingsBlocks) {
-            return $blocks->merge($this->getSettingsBlocks());
-        }
-
-        return $blocks;
+        return $this->registry->getBlocks($withSettingsBlocks);
     }
 
     public function getSettingsBlocks(): Collection
     {
-        return $this->getBlockCollection()->getSettingsList();
+        return $this->registry->getSettingsBlocks();
     }
 
     /**
@@ -282,54 +86,19 @@ class TwillBlocks
      */
     public function getRepeaters(): Collection
     {
-        return $this->getBlockCollection()->getRepeaters();
+        return $this->registry->getRepeaters();
     }
 
     /**
-     * Gets the collection of Block objects from a given directory.
+     * @return Collection|Block[]
      */
-    public function readBlocksFromDirectory(
-        string $directory,
-        string $source,
-        string $type,
-        ?string $renderNamespace = null
-    ): Collection {
-        if (! File::exists($directory)) {
-            return new Collection();
-        }
-
-        return collect(File::files($directory))
-            ->map(function ($file) use ($source, $type, $renderNamespace) {
-                return Block::make($file, $type, $source, null, $renderNamespace);
-            });
+    public function getAll(): Collection
+    {
+        return $this->registry->getAll();
     }
 
-    /**
-     * Gets all the crop configs, also those of component blocks.
-     */
     public function getAllCropConfigs($prefixKey = false): array
     {
-        if (! $this->cropConfigs) {
-            $this->cropConfigs = config()->get('twill.block_editor.crops')
-                + (config()->get('twill.repeaters.crops') ?? []);
-
-            /** @var Block $block */
-            foreach ($this->getBlockCollection() as $block) {
-                if (! $block->componentClass) {
-                    continue;
-                }
-
-                $crops = $block->componentClass::getCrops();
-                if ($crops !== []) {
-                    $this->cropConfigs = array_merge($this->cropConfigs, $crops);
-                }
-            }
-        }
-
-        if ($prefixKey) {
-            return Arr::prependKeysWith($this->cropConfigs, 'block_');
-        }
-
-        return $this->cropConfigs;
+        return $this->registry->getAllCropConfigs($prefixKey);
     }
 }

--- a/src/TwillServiceProvider.php
+++ b/src/TwillServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace A17\Twill;
 
+use A17\Twill\Commands\BlockImport;
 use A17\Twill\Commands\BlockMake;
 use A17\Twill\Commands\Build;
 use A17\Twill\Commands\CapsuleInstall;
@@ -34,6 +35,8 @@ use A17\Twill\Http\ViewComposers\FilesUploaderConfig;
 use A17\Twill\Http\ViewComposers\Localization;
 use A17\Twill\Http\ViewComposers\MediasUploaderConfig;
 use A17\Twill\Models\Block;
+use A17\Twill\Services\Blocks\Block as BlockService;
+use A17\Twill\Services\Blocks\BlockRegistry;
 use A17\Twill\Models\File;
 use A17\Twill\Models\Group;
 use A17\Twill\Models\Media;
@@ -140,17 +143,21 @@ class TwillServiceProvider extends ServiceProvider
         );
 
         foreach (config('twill.block_editor.directories.source.blocks') as $value) {
-            TwillBlocks::$blockDirectories[$value['path']] = [
-                'source' => $value['source'],
-                'renderNamespace' => null,
-            ];
+            Facades\TwillBlocks::registerSourceDirectory(
+                $value['path'],
+                BlockService::TYPE_BLOCK,
+                $value['source'],
+                $value['renderNamespace'] ?? null
+            );
         }
 
         foreach (config('twill.block_editor.directories.source.repeaters') as $value) {
-            TwillBlocks::$repeatersDirectories[$value['path']] = [
-                'source' => $value['source'],
-                'renderNamespace' => null,
-            ];
+            Facades\TwillBlocks::registerSourceDirectory(
+                $value['path'],
+                BlockService::TYPE_REPEATER,
+                $value['source'],
+                $value['renderNamespace'] ?? null
+            );
         }
 
         Relation::morphMap([
@@ -166,6 +173,14 @@ class TwillServiceProvider extends ServiceProvider
     {
         $this->app->bind('twill_util', function () {
             return new TwillUtil();
+        });
+
+        $this->app->singleton(TwillBlocks::class, function ($app) {
+            return new TwillBlocks($app->make(BlockRegistry::class));
+        });
+
+        $this->app->singleton(BlockRegistry::class, function () {
+            return new BlockRegistry();
         });
     }
 
@@ -373,6 +388,7 @@ class TwillServiceProvider extends ServiceProvider
             MakeCapsule::class,
             MakeSingleton::class,
             BlockMake::class,
+            BlockImport::class,
             ListIcons::class,
             ListBlocks::class,
             CreateSuperAdmin::class,


### PR DESCRIPTION
## Summary
- introduce a dedicated `BlockRegistry` service and refactor `TwillBlocks` to delegate block management to it
- register the new registry as a singleton and expose a `registerSourceDirectory` helper used by the service provider
- add a reusable `BlockImporter` service, supporting manifests and archive extraction, plus a `twill:block:import` artisan command and accompanying documentation

## Testing
- `composer test:phpunit` *(fails: vendor/bin/phpunit missing in container)*
- `composer dump-autoload` *(fails: testbench binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d6cda92630832c8a38e27472af80e2